### PR TITLE
fix only allow these keys for signature

### DIFF
--- a/src/Message/Request/AbstractRabobankRequest.php
+++ b/src/Message/Request/AbstractRabobankRequest.php
@@ -111,7 +111,7 @@ abstract class AbstractRabobankRequest extends AbstractRequest
      */
     public function getBaseUrl()
     {
-        if ($this->gateway->getTestMode()) {
+        if ($this->getTestMode()) {
             return $this->baseUrlTesting;
         }
 

--- a/src/Message/Response/AbstractRabobankResponse.php
+++ b/src/Message/Response/AbstractRabobankResponse.php
@@ -58,10 +58,9 @@ class AbstractRabobankResponse extends AbstractResponse
         if (!isset($this->data['signature'])) {
             return;
         }
-        
-        $signatureData = $this->data;
-        unset($signatureData['signature']);
-        unset($signatureData['timestamp']);
+
+        $allowedKeys = array_flip(['order_id', 'status']);
+        $signatureData = array_intersect_key($this->data, $allowedKeys);
 
         $signature = $this->request->gateway->generateSignature($this->flattenData($signatureData));
 

--- a/src/Message/Response/AbstractRabobankResponse.php
+++ b/src/Message/Response/AbstractRabobankResponse.php
@@ -14,6 +14,8 @@ class AbstractRabobankResponse extends AbstractResponse
      */
     protected $request;
 
+    protected $signatureParameters = [];
+
     /**
      * @param AbstractRabobankRequest $request
      * @param array $data
@@ -59,8 +61,15 @@ class AbstractRabobankResponse extends AbstractResponse
             return;
         }
 
-        $allowedKeys = array_flip(['order_id', 'status']);
-        $signatureData = array_intersect_key($this->data, $allowedKeys);
+        $signatureData = $this->data;
+
+        if (!empty($this->signatureParameters) && !isset($signatureData['redirectUrl'])) {
+            $signatureKeys = array_flip($this->signatureParameters);
+            $signatureData = array_intersect_key($signatureData, $signatureKeys);
+        } else {
+            unset($signatureData['signature']);
+            unset($signatureData['timestamp']);
+        }
 
         $signature = $this->request->gateway->generateSignature($this->flattenData($signatureData));
 

--- a/src/Message/Response/CompletePurchaseResponse.php
+++ b/src/Message/Response/CompletePurchaseResponse.php
@@ -25,4 +25,9 @@ class CompletePurchaseResponse extends AbstractRabobankResponse
     {
         return isset($this->data['order_id']) ? $this->data['order_id'] : null;
     }
+
+    public function isPaid()
+    {
+        return $this->isSuccessful();
+    }
 }

--- a/src/Message/Response/CompletePurchaseResponse.php
+++ b/src/Message/Response/CompletePurchaseResponse.php
@@ -4,6 +4,8 @@ namespace Omnipay\Rabobank\Message\Response;
 
 class CompletePurchaseResponse extends AbstractRabobankResponse
 {
+    protected $signatureParameters = ['order_id', 'status'];
+
     public function isSuccessful()
     {
         return isset($this->data['status']) && $this->data['status'] === 'COMPLETED';

--- a/src/Message/Response/PurchaseResponse.php
+++ b/src/Message/Response/PurchaseResponse.php
@@ -6,6 +6,8 @@ use Omnipay\Common\Message\RedirectResponseInterface;
 
 class PurchaseResponse extends AbstractRabobankResponse implements RedirectResponseInterface
 {
+    protected $signatureParameters = ['order_id', 'status'];
+
     /**
      * When you do a `purchase` the request is never successful because
      * you need to redirect off-site to complete the purchase.

--- a/src/Message/Response/StatusResponse.php
+++ b/src/Message/Response/StatusResponse.php
@@ -7,6 +7,7 @@ use Omnipay\Rabobank\Order;
 
 class StatusResponse extends AbstractRabobankResponse
 {
+    protected $signatureParameters = ['moreOrderResultsAvailable', 'orderResults'];
 
     /**
      * Indication if there are more order statuses available than in this response.


### PR DESCRIPTION
only allow the order_id and status key for the signature validation as given in the doc

[https://developer.rabobank.nl/omnikassa-payment-api](https://developer.rabobank.nl/omnikassa-payment-api)